### PR TITLE
customize schema change for RAI application

### DIFF
--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -262,13 +262,13 @@ class SnowflakeSchemachangeSession:
     try:
         with open(token_file, "r") as f:
             token = f.read().strip()
-            return token, None
+            return token
     except FileNotFoundError:
-        return None, f"Token file not found: {token_file}"
+        raise KeyError(f"Token file not found: {token_file}")
     except PermissionError as e:
-        return None, f"Permission error reading token file: {e}"
+        raise KeyError(f"Permission error reading token file: {e}")
     except Exception as e:
-        return None, f"Error reading token file: {e}"
+        raise KeyError(f"Error reading token file: {e}")
 
   def get_oauth_token(self):
     req_info = { \

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -244,6 +244,32 @@ class SnowflakeSchemachangeSession:
     if hasattr(self, 'con'):
       self.con.close()
 
+  def read_master_token(self):
+    """Reads the master token from a file.
+
+    This function attempts to read the master token from a file specified by the
+    SNOWFLAKE_TOKEN_FILE environment variable. If the file cannot be opened or
+    read, an error is returned.
+
+    Returns:
+        A tuple containing the master token as a string and None, or None and an
+        error message if there is an error.
+    """
+    token_file = os.environ.get("SNOWFLAKE_TOKEN_FILE")
+    if not token_file:
+        token_file = os.path.expanduser("/snowflake/session/token")
+
+    try:
+        with open(token_file, "r") as f:
+            token = f.read().strip()
+            return token, None
+    except FileNotFoundError:
+        return None, f"Token file not found: {token_file}"
+    except PermissionError as e:
+        return None, f"Permission error reading token file: {e}"
+    except Exception as e:
+        return None, f"Error reading token file: {e}"
+
   def get_oauth_token(self):
     req_info = { \
       "url":self.oauth_config['token-provider-url'], \
@@ -285,7 +311,7 @@ class SnowflakeSchemachangeSession:
       # Determine the type of Authenticator
       # OAuth based authentication
       if snowflake_authenticator.lower() == 'oauth':
-        oauth_token = self.get_oauth_token()
+        oauth_token = self.read_master_token()
 
         if self.verbose:
           print( _log_auth_type % 'Oauth Access Token')

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -505,7 +505,8 @@ class SnowflakeSchemachangeSession:
 
 def deploy_command(config):
   # Make sure we have the required connection info, all of the below needs to be present.
-  req_args = set(['snowflake_account','snowflake_user','snowflake_role','snowflake_warehouse'])
+  #req_args = set(['snowflake_account','snowflake_user','snowflake_role','snowflake_warehouse'])
+  req_args = set(['snowflake_account'])
   provided_args = {k:v for (k,v) in config.items() if v}
   missing_args = req_args -provided_args.keys()
   if len(missing_args)>0:

--- a/schemachange/cli.py
+++ b/schemachange/cli.py
@@ -230,7 +230,8 @@ class SnowflakeSchemachangeSession:
       ,"role": config['snowflake_role'],"warehouse": config['snowflake_warehouse'] \
       ,"database": config['snowflake_database'],"schema": config['snowflake_schema'], "host": config['snowflake_host'] \
       ,"application": _snowflake_application_name \
-      ,"session_parameters":session_parameters}
+      ,"session_parameters":session_parameters \
+      ,"insecure_mode":True}
 
     self.oauth_config = config['oauth_config']
     self.autocommit = config['autocommit']


### PR DESCRIPTION
customize the schema change tool to use oauth master tokens and allow empty snowflake user, role, and warehouse if possible